### PR TITLE
WIP First implementation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,8 @@ dependencies {
 
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.mockito:mockito-core:5.4.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.4.0'
 }
 
 application {

--- a/app/src/main/groovy/io/seqera/events/utils/db/ConnectionImpl.groovy
+++ b/app/src/main/groovy/io/seqera/events/utils/db/ConnectionImpl.groovy
@@ -1,0 +1,20 @@
+package io.seqera.events.utils.db
+
+import java.sql.Connection
+
+class ConnectionImpl {
+
+    private PooledConnectionImpl pooledConnection
+
+    @Delegate
+    private Connection connection
+
+    ConnectionImpl(PooledConnectionImpl pooledConnection) {
+        this.pooledConnection = pooledConnection
+        this.connection = pooledConnection.getConnection()
+    }
+
+    void close() {
+        pooledConnection.release()
+    }
+}

--- a/app/src/main/groovy/io/seqera/events/utils/db/ConnectionProviderImpl.groovy
+++ b/app/src/main/groovy/io/seqera/events/utils/db/ConnectionProviderImpl.groovy
@@ -9,10 +9,11 @@ class ConnectionProviderImpl implements ConnectionProvider {
     String serverUrl
     String username
     String password
-    String driver;
+    String driver
 
     @Override
     Sql getConnection() {
-        return  Sql.newInstance(serverUrl, username, password, driver)
+        def pool = new PooledDataSource(serverUrl, username, password, driver)
+        return new Sql(pool)
     }
 }

--- a/app/src/main/groovy/io/seqera/events/utils/db/PooledConnectionImpl.groovy
+++ b/app/src/main/groovy/io/seqera/events/utils/db/PooledConnectionImpl.groovy
@@ -1,0 +1,52 @@
+package io.seqera.events.utils.db
+
+import javax.sql.ConnectionEvent
+import javax.sql.ConnectionEventListener
+import javax.sql.PooledConnection
+import javax.sql.StatementEventListener
+import java.sql.Connection
+import java.sql.SQLException
+
+class PooledConnectionImpl implements PooledConnection {
+
+    private Connection connection
+
+    private Set<ConnectionEventListener> listeners = new HashSet<>()
+
+    PooledConnectionImpl(Connection connection) {
+        this.connection = connection
+    }
+
+    @Override
+    Connection getConnection() throws SQLException {
+        return connection
+    }
+
+    @Override
+    void close() throws SQLException {
+        connection.close()
+    }
+
+    void release() {
+        def event = new ConnectionEvent(this)
+        for (listener in listeners) listener.connectionClosed(event)
+    }
+
+    @Override
+    void addConnectionEventListener(ConnectionEventListener listener) {
+        listeners.add(listener)
+    }
+
+    @Override
+    void removeConnectionEventListener(ConnectionEventListener listener) {
+        listeners.remove(listeners)
+    }
+
+    @Override
+    void addStatementEventListener(StatementEventListener listener) {
+    }
+
+    @Override
+    void removeStatementEventListener(StatementEventListener listener) {
+    }
+}

--- a/app/src/main/groovy/io/seqera/events/utils/db/PooledDataSource.groovy
+++ b/app/src/main/groovy/io/seqera/events/utils/db/PooledDataSource.groovy
@@ -1,0 +1,130 @@
+package io.seqera.events.utils.db
+
+import groovy.sql.Sql
+
+import javax.sql.ConnectionEvent
+import javax.sql.ConnectionEventListener
+import javax.sql.DataSource
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.SQLException
+import java.sql.SQLFeatureNotSupportedException
+import java.util.logging.Logger
+
+class PooledDataSource implements DataSource, ConnectionEventListener {
+
+    static int DEFAULT_LOGIN_TIMEOUT = 300
+    static int DEFAULT_IDLE_TIMEOUT = 0
+
+    static int DEFAULT_INITIAL_POOL_SIZE = 10
+
+    private int loginTimeout = DEFAULT_LOGIN_TIMEOUT
+    private int idleTimeout = DEFAULT_IDLE_TIMEOUT
+
+    private int initialPoolSize = DEFAULT_INITIAL_POOL_SIZE
+
+    private String serverUrl
+    private String username
+    private String password
+
+    private def connections = new PooledConnectionImpl[initialPoolSize]
+
+    private PrintWriter logWriter = System.out.newPrintWriter()
+
+    PooledDataSource(
+            String serverUrl,
+            String username,
+            String password,
+            String driver,
+            int loginTimeout = DEFAULT_LOGIN_TIMEOUT,
+            int idleTimeout = DEFAULT_IDLE_TIMEOUT,
+            int initialPoolSize = DEFAULT_INITIAL_POOL_SIZE
+    ) {
+
+        assert loginTimeout >= 0
+        assert idleTimeout >= 0
+        assert initialPoolSize > 0
+
+        Sql.loadDriver(driver)
+        this.serverUrl = serverUrl
+        this.username = username
+        this.password = password
+        this.loginTimeout = loginTimeout
+        this.idleTimeout = idleTimeout
+        this.initialPoolSize = initialPoolSize
+
+        allocateConnections(initialPoolSize, serverUrl, username, password)
+    }
+
+    @Override
+    Connection getConnection() throws SQLException {
+        return new ConnectionImpl(connections[0]) // TODO
+    }
+
+    @Override
+    Connection getConnection(String username, String password) throws SQLException {
+        throw new SQLFeatureNotSupportedException()
+    }
+
+    @Override
+    void connectionClosed(ConnectionEvent event) {
+        // TODO Re-allocate resources
+    }
+
+    @Override
+    void connectionErrorOccurred(ConnectionEvent event) {
+
+    }
+
+    @Override
+    PrintWriter getLogWriter() throws SQLException {
+        return logWriter
+    }
+
+    @Override
+    void setLogWriter(PrintWriter out) throws SQLException {
+        this.logWriter = out
+    }
+
+    @Override
+    void setLoginTimeout(int seconds) throws SQLException {
+        this.loginTimeout = seconds
+    }
+
+    @Override
+    int getLoginTimeout() throws SQLException {
+        return loginTimeout
+    }
+
+    long getIdleTimeout() {
+        return idleTimeout
+    }
+
+    int getInitialPoolSize() {
+        return initialPoolSize
+    }
+
+    @Override
+    Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException()
+    }
+
+    @Override
+    <T> T unwrap(Class<T> type) throws SQLException {
+        throw new SQLFeatureNotSupportedException()
+    }
+
+    @Override
+    boolean isWrapperFor(Class<?> type) throws SQLException {
+        return false
+    }
+
+    private void allocateConnections(int initialPoolSize, String serverUrl, String username, String password) {
+        for (i in 0..initialPoolSize - 1) {
+            def connection = DriverManager.getConnection(serverUrl, username, password)
+            def pooledConnection = new PooledConnectionImpl(connection)
+            pooledConnection.addConnectionEventListener(this)
+            connections[i] = pooledConnection
+        }
+    }
+}

--- a/app/src/test/groovy/io/seqera/events/utils/db/PooledDataSourceTest.groovy
+++ b/app/src/test/groovy/io/seqera/events/utils/db/PooledDataSourceTest.groovy
@@ -1,0 +1,72 @@
+package io.seqera.events.utils.db
+
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+import java.sql.Connection
+import java.sql.Driver
+import java.sql.DriverManager
+
+import static io.seqera.events.utils.db.PooledDataSource.DEFAULT_IDLE_TIMEOUT
+import static io.seqera.events.utils.db.PooledDataSource.DEFAULT_LOGIN_TIMEOUT
+import static org.mockito.ArgumentMatchers.any
+import static org.mockito.ArgumentMatchers.eq
+import static org.mockito.Mockito.*
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PooledDataSourceTest {
+
+    private Driver driverMock
+    private PooledDataSource dataSource
+
+    private def connectionMocks = [
+            mock(Connection.class),
+            mock(Connection.class),
+            mock(Connection.class)
+    ]
+
+    @BeforeAll
+    void beforeAll() {
+        driverMock = mock(Driver.class)
+
+        // We need to stub the driver to allow DriverManager check the connection
+        when(driverMock.acceptsURL(eq("jdbc:test:events"))).thenReturn(true)
+
+        def connectionMocksCopy = connectionMocks.clone()
+        when(driverMock.connect(eq("jdbc:test:events"), any())).thenAnswer {
+            // Return new connection mock per call
+            connectionMocksCopy.remove(0)
+        }
+
+        DriverManager.registerDriver(driverMock, {})
+
+        dataSource = new PooledDataSource(
+                "jdbc:test:events",
+                "test",
+                "",
+                Driver.class.name,
+                DEFAULT_LOGIN_TIMEOUT,
+                DEFAULT_IDLE_TIMEOUT,
+                3,
+
+        )
+    }
+
+    @Test
+    void 'database connections are allocated at startup'() {
+        dataSource.getConnection()
+
+        verify(driverMock, times(dataSource.initialPoolSize))
+                .connect(eq("jdbc:test:events"), any())
+    }
+
+    @Test
+    void 'database connections are not closed by the application code'() {
+        dataSource.getConnection().close()
+
+        for (connectionMock in connectionMocks) {
+            verify(connectionMock, never()).close()
+        }
+    }
+}


### PR DESCRIPTION
Rely on data source constructor of the `groovy.sql.Sql` class to use a pooled data source.

To be implemented:

* Connection re-allocation
* Connection idle timeout

Fixes:

   * #1 